### PR TITLE
Selkeytys .env -tiedoston määrittelyyn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # textec
+
 [![CI](https://github.com/jobatabs/textec/actions/workflows/ci.yaml/badge.svg)](https://github.com/jobatabs/textec/actions/workflows/ci.yaml)
 [![CodeQL](https://github.com/jobatabs/textec/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/jobatabs/textec/actions/workflows/github-code-scanning/codeql)
 [![Pylint](https://github.com/jobatabs/textec/actions/workflows/pylint.yml/badge.svg)](https://github.com/jobatabs/textec/actions/workflows/pylint.yml)
@@ -14,34 +15,35 @@ https://ohjelmistotuotanto-hy.github.io/speksi/
 
 # Asennusohjeet
 
-1. ``git clone git@github.com:jobatabs/textec.git``
-2. ``cd textec``
-3. ``pip install poetry``
-4. ``poetry install``
+1. `git clone git@github.com:jobatabs/textec.git`
+2. `cd textec`
+3. `pip install poetry`
+4. `poetry install`
 
 # .env tiedoston luominen
 
-Sovellus käyttää PostgreSQL-tietokantaa, ja sen käynnistämiseksi tarvitaan `.env`-tiedosto, joka sisältää seuraavat ympäristömuuttujat: 
+Sovellus käyttää PostgreSQL-tietokantaa, ja sen käynnistämiseksi tarvitaan `.env`-tiedosto, joka sisältää seuraavat ympäristömuuttujat:
 
-```env 
-DATABASE_URL=postgresql://xxx
+```env
+DATABASE_URL=postgresql://valinnainen_käyttäjä:valinnainen_salasana@localhost:haluamasiporttinumero/tietokannan_nimi
 TEST_ENV=true
 SECRET_KEY=satunnainen_merkkijono
 ```
 
 # Sovelluksen käynnistäminen
 
-1. ``poetry run python3 src/db_helper.py``
-2. ``poetry run python3 src/index.py``
+1. `poetry run python3 src/db_helper.py`
+2. `poetry run python3 src/index.py`
 
 # Testien ajo
 
-1. ``poetry run pytest src/tests``
-2. ``poetry run robot src/story_tests``
+1. `poetry run pytest src/tests`
+2. `poetry run robot src/story_tests`
 
 # Definition of done
 
 Ollakseen valmis, user storyn toteutuksen tulee olla
+
 - analysoitu (hyväksymiskriteerit kirjattu Robot-testein)
 - suunniteltu (jaettu taskeihin)
 - ohjelmoitu (huom. autopep8)
@@ -54,7 +56,3 @@ Ollakseen valmis, user storyn toteutuksen tulee olla
 [Käyttäjä voi lisätä 3 eri tyyppistä lähdettä](https://github.com/jobatabs/textec/blob/main/src/story_tests/add_reference.robot)
 
 [Käyttäjä voi muokata lisättyä lähdettä](https://github.com/jobatabs/textec/blob/main/src/story_tests/edit_reference.robot)
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ https://ohjelmistotuotanto-hy.github.io/speksi/
 Sovellus käyttää PostgreSQL-tietokantaa, ja sen käynnistämiseksi tarvitaan `.env`-tiedosto, joka sisältää seuraavat ympäristömuuttujat:
 
 ```env
-DATABASE_URL=postgresql://valinnainen_käyttäjä:valinnainen_salasana@localhost:haluamasiporttinumero/tietokannan_nimi
+DATABASE_URL=postgresql://käyttäjä:salasana@localhost:porttinumero/tietokannan_nimi
 TEST_ENV=true
 SECRET_KEY=satunnainen_merkkijono
 ```

--- a/README.md
+++ b/README.md
@@ -57,3 +57,4 @@ Ollakseen valmis, user storyn toteutuksen tulee olla
 
 
 
+


### PR DESCRIPTION
laitettu täytettävät kohdat DATABASE_URL -riville placeholder -arvoilla, jolloin sovelluksen käyttäjän ei tarvitse tuntea formaattia ulkoa.